### PR TITLE
Remove uncessary meteo variables

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -113,13 +113,11 @@ function _synthetic_meteo_row(;
         hour_end=Dates.format(Dates.Time(end_dt), Dates.DateFormat("HH:MM:SS")),
         step_duration=duration_seconds,
         latitude=0.0,
-        relativeHumidity=60.0,
         RI_PAR_f=ri_par_f,
         RI_NIR_f=ri_nir_f,
         direct_fraction=direct_fraction,
         sun_azimut=sun_azimut,
         sun_elevation=sun_elevation,
-        use="relativeHumidity RI_PAR_f",
     )
 end
 

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -129,7 +129,6 @@ meteo = MeteoTable(
             hour_start=Time("06:00:00") + Hour(i-1),
             duration=Hour(1),
             clearness=0.6,
-            relativeHumidity=60.0,
         )
     for i in 1:10],
     (latitude=15.0, file="interactive",),

--- a/docs/src/reference_meteo.md
+++ b/docs/src/reference_meteo.md
@@ -70,7 +70,7 @@ ARCHIMED-style meteo files often begin with metadata comments such as:
 #' name: Aquiares
 #' latitude: 15.0
 #' altitude: 100.0
-#' use: relativeHumidity clearness
+#' use: clearness
 ```
 
 ### Dynamically In Julia
@@ -333,8 +333,6 @@ meteo = MeteoTable(
             latitude=15.0,
             RI_PAR_f=350.0,
             RI_NIR_f=250.0,
-            relativeHumidity=60.0,
-            use="relativeHumidity",
         ),
     ],
     (latitude=15.0, file="interactive",),
@@ -381,10 +379,12 @@ Historical files may also contain:
 - `VPD`
 - `wind`
 - `atmosphereCO2_ppm`
+- `Re_SW_f`
 
 Those variables were important in the original ARCHIMED energy-balance and
-photosynthesis workflows. In the current light-only package, they are mostly
-contextual unless a specific forcing reconstruction uses them.
+photosynthesis workflows. In the current light-only package, they are ignored
+by the light solver. They may remain in legacy files without changing the
+result, but they are not required.
 
 ## Practical Advice
 

--- a/src/sky.jl
+++ b/src/sky.jl
@@ -254,53 +254,6 @@ function _use_tokens(row)
     return String[]
 end
 
-function _has_any_column(row, candidates::Vector{Symbol})
-    names = propertynames(row)
-    for c in candidates
-        c in names && return true
-    end
-    return false
-end
-
-function _normalize_humidity_use_token(token::AbstractString)
-    s = lowercase(strip(String(token)))
-    if s in ("relativehumidity", "relative_humidity", "rh")
-        return "relativeHumidity"
-    elseif s == "vpd"
-        return "VPD"
-    end
-    return ""
-end
-
-function _validate_meteo_humidity_inputs(use_tokens::AbstractVector{<:AbstractString}, row)
-    has_rh = _has_any_column(row, [:relativeHumidity, :relative_humidity, :RH, :rh])
-    has_vpd = _has_any_column(row, [:VPD, :vpd])
-
-    uses = String[]
-    for u in use_tokens
-        uu = _normalize_humidity_use_token(u)
-        isempty(uu) || push!(uses, uu)
-    end
-    uses = unique(uses)
-
-    if any(==("relativeHumidity"), uses) && !has_rh
-        error("meteo consistency error: missing relativeHumidity column specified in 'use' line")
-    end
-    if any(==("VPD"), uses) && !has_vpd
-        error("meteo consistency error: missing VPD column specified in 'use' line")
-    end
-
-    if has_rh && has_vpd
-        isempty(uses) && error("meteo consistency error: missing 'use' for columns relativeHumidity/VPD")
-        length(uses) == 1 || error("meteo consistency error: multiple uses: relativeHumidity/VPD")
-    elseif !has_rh && !has_vpd
-        error("meteo consistency error: missing column relativeHumidity/VPD")
-    else
-        # Exactly one humidity source is available.
-        length(uses) <= 1 || error("meteo consistency error: multiple uses: relativeHumidity/VPD")
-    end
-end
-
 function _validate_meteo_radiation_inputs(use_tokens::AbstractVector{<:AbstractString}, has_cl::Bool, has_sw::Bool, has_par::Bool, has_nir::Bool)
     key_cl = "clearness"
     keys_set2 = ("RI_SW_f", "RI_PAR_f", "RI_NIR_f")
@@ -573,7 +526,6 @@ function compute_sky(meteo_row, options::LightOptions)
     clearness = clearness_raw
 
     use_tokens = _use_tokens(meteo_row)
-    _validate_meteo_humidity_inputs(use_tokens, meteo_row)
     _validate_meteo_radiation_inputs(
         use_tokens,
         !isnan(clearness_raw),

--- a/test/fast_fixtures/simpleplant_16_notoric/input/meteo.csv
+++ b/test/fast_fixtures/simpleplant_16_notoric/input/meteo.csv
@@ -1,4 +1,4 @@
 #' latitude: 15.0  # in degrees
 #' altitude: 100.0 # in degrees
-date;hour_start;hour_end;temperature;relativeHumidity;clearness;wind
-2016/06/12;10:00:00;10:30:00;17;67;0.63;13
+date;hour_start;hour_end;clearness
+2016/06/12;10:00:00;10:30:00;0.63

--- a/test/fast_fixtures/simpleplant_16_toric/input/meteo.csv
+++ b/test/fast_fixtures/simpleplant_16_toric/input/meteo.csv
@@ -1,4 +1,4 @@
 #' latitude: 15.0  # in degrees
 #' altitude: 100.0 # in degrees
-date;hour_start;hour_end;temperature;relativeHumidity;clearness;wind
-2016/06/12;10:00:00;10:30:00;17;67;0.63;13
+date;hour_start;hour_end;clearness
+2016/06/12;10:00:00;10:30:00;0.63

--- a/test/fast_fixtures/sky_06_direct/input/meteo.csv
+++ b/test/fast_fixtures/sky_06_direct/input/meteo.csv
@@ -1,4 +1,4 @@
 #' latitude: 15.0
 #' altitude: 100.0
-date;hour_start;hour_end;temperature;relativeHumidity;clearness;wind
-2019/04/04;09:00:00;09:30:00;24;70;0.35;2
+date;hour_start;hour_end;clearness
+2019/04/04;09:00:00;09:30:00;0.35

--- a/test/fast_fixtures/sky_16_turtle/input/meteo.csv
+++ b/test/fast_fixtures/sky_16_turtle/input/meteo.csv
@@ -1,4 +1,4 @@
 #' latitude: 43.6
 #' altitude: 250.0
-date;hour_start;hour_end;temperature;relativeHumidity;RI_SW_f;wind
-2019/06/21;12:00:00;12:30:00;28;55;820.0;3
+date;hour_start;hour_end;RI_SW_f
+2019/06/21;12:00:00;12:30:00;820.0

--- a/test/fast_fixtures/sky_46_direct/input/meteo.csv
+++ b/test/fast_fixtures/sky_46_direct/input/meteo.csv
@@ -1,4 +1,4 @@
 #' latitude: -21.1
 #' altitude: 1200.0
-date;hour_start;hour_end;temperature;relativeHumidity;clearness;wind
-2019/09/22;12:00:00;12:30:00;18;60;0.68;4
+date;hour_start;hour_end;clearness
+2019/09/22;12:00:00;12:30:00;0.68

--- a/test/regression_matrix/synthetic_support.jl
+++ b/test/regression_matrix/synthetic_support.jl
@@ -126,13 +126,11 @@ function _synthetic_meteo_row(;
     start_time::Dates.Time=Dates.Time(12),
     duration_seconds::Float64=1.0,
     latitude::Float64=0.0,
-    relative_humidity::Float64=60.0,
     ri_par_f::Float64=100.0,
     ri_nir_f::Float64=0.0,
     direct_fraction::Float64=1.0,
     sun_azimut::Float64=180.0,
     sun_elevation::Float64=90.0,
-    use::String="relativeHumidity RI_PAR_f",
 )
     start_dt = Dates.DateTime(date, start_time)
     end_dt = start_dt + Dates.Millisecond(round(Int, duration_seconds * 1000))
@@ -142,13 +140,11 @@ function _synthetic_meteo_row(;
         hour_end=Dates.format(Dates.Time(end_dt), Dates.DateFormat("HH:MM:SS")),
         step_duration=duration_seconds,
         latitude=latitude,
-        relativeHumidity=relative_humidity,
         RI_PAR_f=ri_par_f,
         RI_NIR_f=ri_nir_f,
         direct_fraction=direct_fraction,
         sun_azimut=sun_azimut,
         sun_elevation=sun_elevation,
-        use=use,
     )
 end
 

--- a/test/synthetic_scene_support.jl
+++ b/test/synthetic_scene_support.jl
@@ -137,13 +137,11 @@ function _synthetic_meteo_row(;
     start_time::Dates.Time=Dates.Time(12),
     duration_seconds::Float64=1.0,
     latitude::Float64=0.0,
-    relative_humidity::Float64=60.0,
     ri_par_f::Float64=100.0,
     ri_nir_f::Float64=0.0,
     direct_fraction::Float64=1.0,
     sun_azimut::Float64=180.0,
     sun_elevation::Float64=90.0,
-    use::String="relativeHumidity RI_PAR_f",
 )
     start_dt = Dates.DateTime(date, start_time)
     end_dt = start_dt + Dates.Millisecond(round(Int, duration_seconds * 1000))
@@ -153,13 +151,11 @@ function _synthetic_meteo_row(;
         hour_end=Dates.format(Dates.Time(end_dt), Dates.DateFormat("HH:MM:SS")),
         step_duration=duration_seconds,
         latitude=latitude,
-        relativeHumidity=relative_humidity,
         RI_PAR_f=ri_par_f,
         RI_NIR_f=ri_nir_f,
         direct_fraction=direct_fraction,
         sun_azimut=sun_azimut,
         sun_elevation=sun_elevation,
-        use=use,
     )
 end
 


### PR DESCRIPTION
We still enforce relative humidity and vpd as input columns for the meteo, but they're not needed by the light interception algorithms. This removes the need to add them.